### PR TITLE
Add new commands 'stream' and 'wifi' to configure camera settings.

### DIFF
--- a/pmca-console.py
+++ b/pmca-console.py
@@ -46,6 +46,15 @@ def main():
  gps = subparsers.add_parser('gps', description='Update GPS assist data')
  gps.add_argument('-d', dest='driver', choices=['libusb', 'native'], help='specify the driver')
  gps.add_argument('-f', dest='file', type=argparse.FileType('rb'), help='assistme.dat file')
+ stream = subparsers.add_parser('stream', description='Update Streaming configuration')
+ stream.add_argument('-d', dest='driver', choices=['libusb', 'native'], help='specify the driver')
+ stream.add_argument('-f', dest='file', type=argparse.FileType('w'), help='store current settings to file')
+ stream.add_argument('-w', dest='write', type=argparse.FileType('r'), help='program camera settings from file')
+ wifi = subparsers.add_parser('wifi', description='Update WiFi configuration')
+ wifi.add_argument('-d', dest='driver', choices=['libusb', 'native'], help='specify the driver')
+ wifi.add_argument('-m', dest='multi', action='store_true', help='Read/Write "Multi-WiFi" settings')
+ wifi.add_argument('-f', dest='file', type=argparse.FileType('w'), help='store current settings to file')
+ wifi.add_argument('-w', dest='write', type=argparse.FileType('r'), help='program camera settings from file')
 
  args = parser.parse_args()
  if args.command == 'info':
@@ -70,6 +79,10 @@ def main():
   updaterShellCommand(args.model, args.fdatFile, args.driver)
  elif args.command == 'gps':
   gpsUpdateCommand(args.file, args.driver)
+ elif args.command == 'stream':
+  streamingCommand(args.write, args.file, args.driver)
+ elif args.command == 'wifi':
+  wifiCommand(args.write, args.file, args.multi, args.driver)
  else:
   parser.print_usage()
 

--- a/pmca/usb/sony.py
+++ b/pmca/usb/sony.py
@@ -337,9 +337,17 @@ class SonyExtCmdCamera(object):
     info3._asdict(),
    ] for e in d.items())
 
+ def setLiveStreamingServiceInfo(self, data):
+  """Sets the live streaming ustream configuration"""
+  return self._sendCommand(self.SONY_CMD_NetworkServiceInfo_SetLiveStreamingServiceInfo, data)
+
  def getLiveStreamingSocialInfo(self):
   """Returns the live streaming social media configuration"""
   return self.LiveStreamingSNSInfo.unpack(self._sendCommand(self.SONY_CMD_NetworkServiceInfo_GetLiveStreamingSNSInfo))
+
+ def setLiveStreamingSocialInfo(self, data):
+  """Sets the live streaming social media configuration"""
+  return self._sendCommand(self.SONY_CMD_NetworkServiceInfo_SetLiveStreamingSNSInfo, data)
 
  def _parseAPs(self, data):
   for i in range(parse32le(data.read(4))):
@@ -350,10 +358,18 @@ class SonyExtCmdCamera(object):
   for ap in self._parseAPs(BytesIO(self._sendCommand(self.SONY_CMD_NetworkServiceInfo_GetWifiAPInfo))):
    yield ap
 
+ def setWifiAPInfo(self, data):
+  """Sets the live streaming access point configuration"""
+  return self._sendCommand(self.SONY_CMD_NetworkServiceInfo_SetWifiAPInfo, data)
+
  def getMultiWifiAPInfo(self):
   """Returns the live streaming multi access point configuration"""
   for ap in self._parseAPs(BytesIO(self._sendCommand(self.SONY_CMD_NetworkServiceInfo_GetMultiWifiAPInfo))):
    yield ap
+
+ def setMultiWifiAPInfo(self, data):
+  """Sets the live streaming multi access point configuration"""
+  return self._sendCommand(self.SONY_CMD_NetworkServiceInfo_SetMultiWifiAPInfo, data)
 
 
 class SonyUpdaterSequenceError(Exception):


### PR DESCRIPTION
New commands 'stream' and 'wifi' allow control of the Streaming and WiFi functions of
the attached camera. These settings can also be written to and read from files.

For Streaming settings, the official tools should be used to allocate the appropriate
crypto-tokens, the other values can be changed at will. Ustream documentation explains
how to obtain the OAuth2 tokens, the others are available from user's profile.
```

$ python3 pmca-console.py stream
No native drivers available
Using drivers libusb-MSC, libusb-MTP
Looking for Sony devices

Querying mass storage device
Sony Camcorder is a camera in mass storage mode

twitterEnabled:     0
twitterConsumerKey: o9aaaaaaaaaaaaaaaaaqg
twitterConsumerSecret: TTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaasA
twitterAccessToken1:
twitterAccessTokenSecret:
twitterMessage:     Live Streaming from Action Cam by PONY
facebookEnabled:    0
facebookAccessToken:
facebookMessage:    Live Streaming from Action Cam by PONY
service:            0
enabled:            1
macId:              e8aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa43
macSecret:          b5aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa57
macIssueTime:       3df9085a00000000
unknown:            1
channels:           [23xxxxxx]
shortURL:           http://ustre.am/1Aaaa
videoFormat:        1
supportedFormats:   [1, 3]
enableRecordMode:   0
videoTitle:         Recorded with Action Cam by Sony
videoDescription:   Shot 100% with Sony's Action Cam #SonyActionCam #ProveYourself
videoTag:           Made on GitHub
```

Easiest technique is to download settings from camera, edit and write back.

```
$ python3 pmca-console.py stream -f stream.cfg
$ vim stream.cfg
$ python3 pmca-console.py stream -w stream.cfg
```
or
```
$ python3 pmca-console.py wifi -f wifi.cfg
$ vim wifi.cfg
$ python3 pmca-console.py wifi -w wifi.cfg
```

Tested on Linux/Windows, with Python2.7/3, HDR-AS100V camera