### PR TITLE
use .tobytes() to support python 3.9

### DIFF
--- a/pmca/usb/driver/generic/libusb.py
+++ b/pmca/usb/driver/generic/libusb.py
@@ -68,7 +68,7 @@ class UsbBackend(object):
 
  def read(self, ep, length):
   try:
-   return self.dev.read(ep, length).tostring()
+   return self.dev.read(ep, length).tobytes()
   except usb.core.USBError:
    raise GenericUsbException()
 


### PR DESCRIPTION
Fixes `AttributeError: 'array.array' object has no attribute 'tostring' ` error on python 3.9. AFAICT, with this it seems to work fine on python 3.9.6, osx 11.4.