### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asn1crypto
 axmlparserpy==0.0.4
 certifi
 comtypes; sys_platform == 'win32'
+pyasyncore
 pycparser==2.17 # https://github.com/eliben/pycparser/issues/291
 pycryptodomex
 pyinstaller


### PR DESCRIPTION
this PR manually adds the `pysasyncore` dependency in order to find the `asyncore` module since it's been deprecated on Python 3.12+

it seems like it will need to be replaced with `asyncio`, but this lets the code function for now