### PR TITLE
SyntaxWarning: invalid escape sequence

### DIFF
--- a/pmca/marketclient/__init__.py
+++ b/pmca/marketclient/__init__.py
@@ -29,7 +29,7 @@ def getDevices(portalid):
   'localeid': constants.localeUs,
  }).data)
  contents = data['mycamera']['contents']
- r = re.compile('<div class="camera-manage-box" id="(?P<deviceid>\d*?)">.*?<td class = "w104 h20">(?P<name>.*?)</td>.*?<span class="sirial-hint">Serial:(?P<serial>.*?)</span>', re.DOTALL)
+ r = re.compile(r'<div class="camera-manage-box" id="(?P<deviceid>\d*?)">.*?<td class = "w104 h20">(?P<name>.*?)</td>.*?<span class="sirial-hint">Serial:(?P<serial>.*?)</span>', re.DOTALL)
  return [MarketDevice(**m.groupdict()) for m in r.finditer(contents)]
 
 def getApps(devicename=None):
@@ -42,7 +42,7 @@ def getApps(devicename=None):
   'localeid': constants.localeUs,
  }).data)
  for app in data['contents']:
-  yield MarketApp(app['app_id'], re.sub('\s+', ' ', app['app_name']), app['appimg_url'], None if app['app_price'] == 'Free' else app['app_price'], int(app['regist_date']))
+  yield MarketApp(app['app_id'], re.sub(r'\s+', ' ', app['app_name']), app['appimg_url'], None if app['app_price'] == 'Free' else app['app_price'], int(app['regist_date']))
 
 def downloadXpd(portalid, deviceid, appid):
  """Fetches the xpd file for the given app

--- a/pmca/shell/parser.py
+++ b/pmca/shell/parser.py
@@ -15,7 +15,7 @@ class ArgParser:
    return m
 
  def _consumeWhitespace(self):
-  m = self._consume('\s+')
+  m = self._consume(r'\s+')
   if m:
    return m.group(0)
 
@@ -31,7 +31,7 @@ class ArgParser:
   return self._consumeEscaped('"')
 
  def _consumeUnquoted(self):
-  m = self._consume('([^\s"\'\\\\]|\\\\[^\s])*(\\\\(?=(\s|$)))?')
+  m = self._consume(r'([^\s"\'\\\\]|\\\\[^\s])*(\\\\(?=(\s|$)))?')
   if m and m.group(0) != '':
    return m.group(0)
 
@@ -43,7 +43,7 @@ class ArgParser:
 
  def _consumeArg(self):
   arg = ''
-  while self.available() and not self._match('\s'):
+  while self.available() and not self._match(r'\s'):
    for f in [self._consumeSingleQuoted, self._consumeDoubleQuoted, self._consumeUnquoted]:
     a = f()
     if a is not None:


### PR DESCRIPTION
On MacOs 15.6 with Python 3.13.5 there are couple of warnings

Sony-PMCA-RE/pmca/marketclient/__init__.py:32: SyntaxWarning: invalid escape sequence '\d'
  r = re.compile('<div class="camera-manage-box" id="(?P<deviceid>\d*?)">.*?<td class = "w104 h20">(?P<name>.*?)</td>.*?<span class="sirial-hint">Serial:(?P<serial>.*?)</span>', re.DOTALL)
Sony-PMCA-RE/pmca/marketclient/__init__.py:45: SyntaxWarning: invalid escape sequence '\s'
  yield MarketApp(app['app_id'], re.sub('\s+', ' ', app['app_name']), app['appimg_url'], None if app['app_price'] == 'Free' else app['app_price'], int(app['regist_date']))
Sony-PMCA-RE/pmca/shell/parser.py:18: SyntaxWarning: invalid escape sequence '\s'
  m = self._consume('\s+')
Sony-PMCA-RE/pmca/shell/parser.py:34: SyntaxWarning: invalid escape sequence '\s'
  m = self._consume('([^\s"\'\\\\]|\\\\[^\s])*(\\\\(?=(\s|$)))?')
Sony-PMCA-RE/pmca/shell/parser.py:46: SyntaxWarning: invalid escape sequence '\s'
  while self.available() and not self._match('\s'):

