### PR TITLE
Fix macOS device detection by loading libusb drivers alongside native drivers

### DIFF
--- a/pmca/commands/usb.py
+++ b/pmca/commands/usb.py
@@ -160,11 +160,11 @@ def importDriver(driverName=None):
   raise Exception('Unknown driver')
 
  # Fallback to libusb
- if MscContext is None or (driverName is None and sys.platform == 'win32'):
+ if MscContext is None or (driverName is None and sys.platform in ('win32', 'darwin')):
   from ..usb.driver.generic.libusb import MscContext as MscContext2
- if MtpContext is None or (driverName is None and sys.platform == 'win32'):
+ if MtpContext is None or (driverName is None and sys.platform in ('win32', 'darwin')):
   from ..usb.driver.generic.libusb import MtpContext as MtpContext2
- if (VendorSpecificContext is None and driverName != 'qemu') or (driverName is None and sys.platform == 'win32'):
+ if (VendorSpecificContext is None and driverName != 'qemu') or (driverName is None and sys.platform in ('win32', 'darwin')):
   from ..usb.driver.generic.libusb import VendorSpecificContext as VendorSpecificContext2
 
  drivers = [context() for context in [MscContext, MtpContext, VendorSpecificContext, MscContext2, MtpContext2, VendorSpecificContext2] if context]


### PR DESCRIPTION
## Summary
- On macOS, the native OSX MSC driver may report as available (Sony kext installed) but fail to actually find devices
- Without also loading libusb drivers as fallback, the camera is never detected via the GUI or any command using the default driver
- This adds `darwin` alongside `win32` in the libusb fallback conditions, mirroring the existing Windows behavior where both native and libusb drivers are loaded simultaneously

## Test plan
- [x] Verified `importDriver()` now loads `libusb-MSC` on macOS alongside `OS-X-MSC`
- [x] Verified camera is detected on macOS with default driver settings
- [x] Verified GUI (`pmca-gui.py`) can detect and communicate with camera on macOS