### PR TITLE
Add PAL/NTSC mode tweak

### DIFF
--- a/pmca/platform/backup.py
+++ b/pmca/platform/backup.py
@@ -171,6 +171,7 @@ class BackupInterface:
   self.addProp('recLimit', CompoundBackupProp(dataInterface, [(0x003c0373 + i, 1) for i in range(3)]))
   self.addProp('recLimit4k', BackupProp(dataInterface, 0x003c04b6, 2))
   self.addProp('palNtscSelector', BackupProp(dataInterface, 0x01070148, 1))
+  self.addProp('palNtsc', BackupProp(dataInterface, 0x010704fd, 1))
   self.addProp('language', CompoundBackupProp(dataInterface, [(0x010d008f + i, 1) for i in range(35)]))
   self.addProp('usbAppInstaller', BackupProp(dataInterface, 0x01640001, 1))
 

--- a/pmca/platform/tweaks.py
+++ b/pmca/platform/tweaks.py
@@ -69,6 +69,23 @@ class BooleanBackupTweak(BackupTweak):
   return b'\x01'
 
 
+class PalNtscBackupTweak(BackupTweak):
+ def __init__(self, backend):
+  super(PalNtscBackupTweak, self).__init__(backend, 'palNtsc', True)
+
+ def offValue(self):
+  return b'\x00'
+
+ def onValue(self):
+  return b'\x01'
+
+ def strValue(self):
+  if self.enabled():
+   return 'NTSC'
+  else:
+   return 'PAL'
+
+
 class RecLimitTweak(BackupTweak):
  def __init__(self, backend):
   super(RecLimitTweak, self).__init__(backend, 'recLimit', False)
@@ -151,6 +168,7 @@ class TweakInterface:
   self.addTweak('recLimit4k', 'Disable 4K video recording limit', RecLimit4kTweak(backup))
   self.addTweak('language', 'Unlock all languages', LanguageTweak(backup))
   self.addTweak('palNtscSelector', 'Enable PAL / NTSC selector & warning', BooleanBackupTweak(backup, 'palNtscSelector'))
+  self.addTweak('palNtsc', 'PAL / NTSC', PalNtscBackupTweak(backup))
   self.addTweak('usbAppInstaller', 'Enable USB app installer', BooleanBackupTweak(backup, 'usbAppInstaller'))
 
  def addTweak(self, name, desc, tweak):


### PR DESCRIPTION
This tweak/property controls PAL/NTSC even if the PAL/NTSC selector isn't available.
Discovered on an *unlocked* PAL-region a7RV, tested on a *locked* NTSC-region a7SIII.